### PR TITLE
fix: strip commit message before regex match

### DIFF
--- a/auto_changelog/repository.py
+++ b/auto_changelog/repository.py
@@ -213,7 +213,7 @@ class GitRepository(RepositoryInterface):
     def _parse_conventional_commit(message: str) -> Tuple[str, str, str, str, str]:
         type_ = scope = description = body_footer = body = footer = ""
         # TODO this is less restrictive version of re. I have somewhere more restrictive one, maybe as option?
-        match = re.match(r"^(\w+)(\(\w+\))?!?: (.*)(\n\n[\w\W]*)?$", message)
+        match = re.match(r"^(\w+)(\(\w+\))?!?: (.*)(\n\n[\w\W]*)?$", message.strip())
         if match:
             type_, scope, description, body_footer = match.groups(default="")
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "auto-changelog"
-version = "0.5.1"
+version = "0.5.2"
 description = "Simple tool to generate nice, formatted changelogs from vcs"
 authors = ["Michael F Bryan <michaelfbryan@gmail.com>", "Ken Mijime <kenaco666@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
I found a bug in parsing commit messages created from Pull Requests:
1. Create a Pull Request
2. `Squash and Merge` **leaving description blank**
3. Run auto-changelog on main/master > PR commit is not in the changelog

I've noticed that messages passed to `_parse_conventional_commit` differ depending whether they were pushed directly to main/master or are result of squash and merge option. The latter ones have blank line at the end and are not matched by regex:

```
  @staticmethod
  def _parse_conventional_commit(message: str) -> Tuple[str, str, str, str, str]:
      type_ = scope = description = body = footer = ""
      print(f'parse >{message}<')
      # TODO this is less restrictive version of re. I have somewhere more restrictive one, maybe as option?
      match = re.match(r"^(\w+)(\(\w+\))?: (.*)(\n\n.+)?(\n\n.+)?$", message.strip())
      print('match', match)
```

for MR commits it yields

```
parse >feat: history title

<
match None
```

for regular commits directly to main it yields

```
parse >chore: cleanup
<
match <re.Match object; span=(0, 14), match='chore: cleanup'>
```

after fix this issue is resolved:

```
parse >feat: history title

<
match <re.Match object; span=(0, 19), match='feat: history title'>
```