### PR TITLE
fix: template short flag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,36 +42,40 @@ You can list the command line options by running `auto-changelog --help`:
 .. code-block:: text
 
     Usage: auto-changelog [OPTIONS]
-    
+
     Options:
       -p, --path-repo PATH       Path to the repository's root directory 
                                  [Default: .]
-    
+
       -t, --title TEXT           The changelog's title [Default: Changelog]
       -d, --description TEXT     Your project's description
       -o, --output FILENAME      The place to save the generated changelog
                                  [Default: CHANGELOG.md]
-    
+
       -r, --remote TEXT          Specify git remote to use for links
       -v, --latest-version TEXT  use specified version as latest release
       -u, --unreleased           Include section for unreleased changes
+      --template TEXT            specify template to use [compact] or a path to a
+                                 custom template, default: compact
+
       --diff-url TEXT            override url for compares, use {current} and
                                  {previous} for tags
-    
+
       --issue-url TEXT           Override url for issues, use {id} for issue id
       --issue-pattern TEXT       Override regex pattern for issues in commit
                                  messages. Should contain two groups, original
                                  match and ID used by issue-url.
-    
+
       --tag-pattern TEXT         override regex pattern for release tags. By
                                  default use semver tag names semantic. tag should
                                  be contain in one group named 'version'.
-    
+
       --tag-prefix TEXT          prefix used in version tags, default: ""
       --stdout
       --tag-pattern TEXT         Override regex pattern for release tags
       --starting-commit TEXT     Starting commit to use for changelog generation
       --stopping-commit TEXT     Stopping commit to use for changelog generation
+      --debug                    set logging level to DEBUG
       --help                     Show this message and exit.
 
 

--- a/auto_changelog/__main__.py
+++ b/auto_changelog/__main__.py
@@ -42,7 +42,6 @@ def validate_template(ctx, param, value):
 @click.option("-v", "--latest-version", type=str, help="use specified version as latest release")
 @click.option("-u", "--unreleased", is_flag=True, default=False, help="Include section for unreleased changes")
 @click.option(
-    "-t",
     "--template",
     callback=validate_template,
     default="compact",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "auto-changelog"
-version = "0.5.1"
+version = "0.5.3"
 description = "Simple tool to generate nice, formatted changelogs from vcs"
 authors = ["Michael F Bryan <michaelfbryan@gmail.com>", "Ken Mijime <kenaco666@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
Since there is already shorthand flag `-t` for title, remove it from click option related to `--template`