### PR TITLE
fix: Fixes bug https://github.com/KeNaCo/auto-changelog/issues/112

### DIFF
--- a/auto_changelog/repository.py
+++ b/auto_changelog/repository.py
@@ -46,7 +46,7 @@ class GitRepository(RepositoryInterface):
             locallogger.info("Repository is empty.")
             return changelog
         iter_rev = self._get_iter_rev(starting_commit, stopping_commit)
-        commits = self.repository.iter_commits(iter_rev)
+        commits = self.repository.iter_commits(iter_rev, topo_order=True) # Fixes this bug: https://github.com/KeNaCo/auto-changelog/issues/112
         # Some thoughts here
         #  First we need to check if all commits are "released". If not, we have to create our special "Unreleased"
         #  release. Then we simply iter over all commits, assign them to current release or create new if we find it.


### PR DESCRIPTION
Hi,

in a scenario with parallel feature branches where e.g. feature-branch-1 contains commit-1, then gets commit-2 from merging with feature-branch-2 and feature-branch-2 is doing a release (=creating tag 0.0.1 on master) and then feature-branch-1 is doing a release (=creating tag 0.0.2 on master) commit-1 is falsely shown in the changelog generated by auto-changelog as belonging to 0.0.1 what is wrong! The reason is, that auto-changelog is calling git-rev-list with the default reverse chronological order ...

see https://github.com/KeNaCo/auto-changelog/blob/644e582b2612773cecd1901c8001f78fd6457bc5/auto_changelog/repository.py#L49

... what is wrong in the described scenario. This happens in our team on Gitlab very often and the generated changelog was not usable! The correct behaviour is to traverse in --topo-order >>Show no parents before all of its children are shown, and avoid showing commits on multiple lines of history intermixed. ...<< => 0.0.2 commit-2 0.0.1 commit-1 (commit-1 is not shown, before all of it's children are shown!)

For our internal project, we patched auto-changelog. But of course this is not a clean solution and also others would not benefit  from the fix. This bug is already adressesd in the issue https://github.com/KeNaCo/auto-changelog/issues/112.

If you have any further questions feel free to ask.

KR, Daniel from vector.com